### PR TITLE
Undefined in text of element dragged

### DIFF
--- a/jquery.jstree.js
+++ b/jquery.jstree.js
@@ -798,7 +798,7 @@
 				obj = this._get_node(obj);
 				if(!obj.length) { return false; }
 				var s = this._get_settings().core.html_titles;
-				obj = obj.children("a:eq(0)");
+				obj = obj.find("span");
 				if(s) {
 					obj = obj.clone();
 					obj.children("INS").remove();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lfac/jstree1rc3",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A version of jstree 1.0-rc3 updated to work with jQuery 3.x",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bugfix: When user tries drag an element the ghost return undefined because cant return anchor element, to this case should be better encapsulate span and tries return only text sanitized.